### PR TITLE
Support issuer name in URI generation

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -1,6 +1,8 @@
 from pyotp.otp import OTP
 from pyotp.hotp import HOTP
 from pyotp.totp import TOTP
+import utils
+
 import base64
 import random
 

--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -1,5 +1,5 @@
 from pyotp.otp import OTP
-from . import utils
+from pyotp import utils
 
 
 class HOTP(OTP):

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -1,5 +1,5 @@
 from pyotp.otp import OTP
-from . import utils
+from pyotp import utils
 import datetime
 import time
 

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -28,6 +28,7 @@ def build_uri(secret, name, initial_count=None, issuer_name=None):
     base = 'otpauth://%s/' % otp_type
 
     if issuer_name:
+        issuer_name = urllib.quote(issuer_name)
         base += '%s:' % issuer_name
 
     uri = '%(base)s%(name)s?secret=%(secret)s' % {

--- a/test.py
+++ b/test.py
@@ -42,8 +42,8 @@ class HOTPExampleValuesFromTheRFC(unittest.TestCase):
             'otpauth://hotp/mark@percival?secret=wrn3pqx5uqxqvnqr&counter=12')
 
         self.assertEqual(
-            hotp.provisioning_uri('mark@percival', issuer_name='FooCorp'),
-            'otpauth://hotp/FooCorp:mark@percival?secret=wrn3pqx5uqxqvnqr&counter=0&issuer=FooCorp')
+            hotp.provisioning_uri('mark@percival', issuer_name='FooCorp!'),
+            'otpauth://hotp/FooCorp%21:mark@percival?secret=wrn3pqx5uqxqvnqr&counter=0&issuer=FooCorp%21')
 
 
 class TOTPExampleValuesFromTheRFC(unittest.TestCase):
@@ -73,8 +73,8 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
             'otpauth://totp/mark@percival?secret=wrn3pqx5uqxqvnqr')
 
         self.assertEqual(
-            totp.provisioning_uri('mark@percival', issuer_name='FooCorp'),
-            'otpauth://totp/FooCorp:mark@percival?secret=wrn3pqx5uqxqvnqr&issuer=FooCorp')
+            totp.provisioning_uri('mark@percival', issuer_name='FooCorp!'),
+            'otpauth://totp/FooCorp%21:mark@percival?secret=wrn3pqx5uqxqvnqr&issuer=FooCorp%21')
 
 
 class Timecop(object):


### PR DESCRIPTION
In the Google Authenticator app, if the URI specified doesn't include an `issuer_name` parameter, the Authenticator entry will lack a title.

This PR brings URI generation in `pyotp` closer into compliance with [Authenticator's key URI format](http://code.google.com/p/google-authenticator/wiki/KeyUriFormat).
