### PR TITLE
This adds a valid_until method to the totp object.

### DIFF
--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -90,3 +90,15 @@ class TOTP(OTP):
     def timecode(self, for_time):
         i = time.mktime(for_time.timetuple())
         return int(i / self.interval)
+
+    def valid_until(self, for_time):
+        """
+        Returns the time that a code will expire, given a Time object
+        (datetime.datetime)
+        @param [Time] Time object
+        @return [Time] time the code that would be generated at `for_time`
+        is valid until
+        """
+        valid_time = (self.timecode(for_time) + 1) * self.interval
+        valid_datetime = datetime.datetime.fromtimestamp(valid_time)
+        return valid_datetime

--- a/test.py
+++ b/test.py
@@ -237,6 +237,11 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
         self.assertEqual(len(pyotp.random_base32()), 16)
         self.assertEqual(len(pyotp.random_base32(length=20)), 20)
 
+    def test_valid_until(self):
+        totp = pyotp.TOTP('wrn3pqx5uqxqvnqr')
+        with Timecop(1297553958):
+            self.assertEqual(totp.valid_until(datetime.datetime.now()), datetime.datetime(2011, 02, 12, 15, 39, 30))
+
 
 class CompareDigestTest(unittest.TestCase):
     method = staticmethod(pyotp.utils.compare_digest)


### PR DESCRIPTION
This enables one to get the time that the code returned from totp.at() will be
next generated (assuming that you pass the same time object to both methods)

``` python
In [1]: totp = pyotp.TOTP('wrn3pqx5uqxqvnqr')

In [2]: date = datetime.datetime(2014, 7, 21, 14, 49, 3)

In [3]: totp.valid_until(date)
Out [3]: datetime.datetime(2014, 7, 21, 14, 49, 30)
```
