### PR TITLE
Timing-attack-resistant string comparison

### DIFF
--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -17,7 +17,7 @@ class HOTP(OTP):
         @param [String/Integer] otp the OTP to check against
         @param [Integer] counter the counter of the OTP
         """
-        return unicode(otp) == unicode(self.at(counter))
+        return utils.strings_equal(unicode(otp), unicode(self.at(counter)))
 
     def provisioning_uri(self, name, initial_count=0, issuer_name=None):
         """

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -38,7 +38,7 @@ class TOTP(OTP):
         if for_time is None:
             for_time = datetime.datetime.now()
 
-        return unicode(otp) == unicode(self.at(for_time))
+        return utils.strings_equal(unicode(otp), unicode(self.at(for_time)))
 
     def provisioning_uri(self, name, issuer_name=None):
         """

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -44,3 +44,29 @@ def build_uri(secret, name, initial_count=None, issuer_name=None):
         uri += '&issuer=%s' % issuer_name
 
     return uri
+
+def strings_equal(s1, s2):
+    """
+    Timing-attack resistant string comparison.
+
+    Normal comparison using == will short-circuit on the first mismatching
+    character. This avoids that by scanning the whole string, though we
+    still reveal to a timing attack whether the strings are the same
+    length.
+    """
+    try:
+        # Python 3.3+ and 2.7.7+ include a timing-attack-resistant
+        # comparison function, which is probably more reliable than ours.
+        # Use it if available.
+        from hmac import compare_digest
+        return compare_digest(s1, s2)
+    except ImportError:
+        pass
+
+    if len(s1) != len(s2):
+        return False
+
+    differences = 0
+    for c1, c2 in zip(s1, s2):
+        differences |= ord(c1) ^ ord(c2)
+    return differences == 0

--- a/test.py
+++ b/test.py
@@ -77,6 +77,24 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
             'otpauth://totp/FooCorp%21:mark@percival?secret=wrn3pqx5uqxqvnqr&issuer=FooCorp%21')
 
 
+class StringComparisonTest(unittest.TestCase):
+    def testComparisons(self):
+        self.assertTrue(pyotp.utils.strings_equal("", ""))
+        self.assertTrue(pyotp.utils.strings_equal(u"", u""))
+        self.assertTrue(pyotp.utils.strings_equal("a", "a"))
+        self.assertTrue(pyotp.utils.strings_equal(u"a", u"a"))
+        self.assertTrue(pyotp.utils.strings_equal(u"a", u"a"))
+        self.assertTrue(pyotp.utils.strings_equal("a" * 1000, "a" * 1000))
+        self.assertTrue(pyotp.utils.strings_equal(u"a" * 1000, u"a" * 1000))
+
+        self.assertFalse(pyotp.utils.strings_equal("", "a"))
+        self.assertFalse(pyotp.utils.strings_equal(u"", u"a"))
+        self.assertFalse(pyotp.utils.strings_equal("a", ""))
+        self.assertFalse(pyotp.utils.strings_equal(u"a", u""))
+        self.assertFalse(pyotp.utils.strings_equal("a" * 999 + "b", "a" * 1000))
+        self.assertFalse(pyotp.utils.strings_equal(u"a" * 999 + u"b", u"a" * 1000))
+
+
 class Timecop(object):
     """
     Half-assed clone of timecop.rb, just enough to pass our tests.


### PR DESCRIPTION
The current implementation leaks information about the correct value of
the OTP code in the string comparison, since python's string comparison
is short-circuiting. This fixes the vulnerability. See
http://crypto.stanford.edu/~dabo/papers/ssl-timing.pdf for why this is
important even in network applications.
