### PR TITLE
Update OWASP Authentication Cheat Sheet link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,7 +123,7 @@ Links
 * `RFC 6238: TOTP: Time-Based One-Time Password Algorithm <https://tools.ietf.org/html/rfc6238>`_
 * `ROTP <https://github.com/mdp/rotp>`_ - Original Ruby OTP library by `Mark Percival <https://github.com/mdp>`_
 * `OTPHP <https://github.com/lelag/otphp>`_ - PHP port of ROTP by `Le Lag <https://github.com/lelag>`_
-* `OWASP Authentication Cheat Sheet <https://www.owasp.org/index.php/Authentication_Cheat_Sheet>`_
+* `OWASP Authentication Cheat Sheet <https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Authentication_Cheat_Sheet.md>`_
 * `NIST SP 800-63-3: Digital Authentication Guideline <https://pages.nist.gov/800-63-3/>`_
 
 For new applications:


### PR DESCRIPTION
In README.

The Cheat Sheet Series project [has been moved to GitHub](https://www.owasp.org/index.php/Authentication_Cheat_Sheet).