### PR TITLE
Fix comparison of unicode chars

### DIFF
--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import sys
 import unicodedata
 try:
     from itertools import izip_longest
@@ -106,4 +107,7 @@ def strings_equal(s1, s2):
     """
     s1 = unicodedata.normalize('NFKC', s1)
     s2 = unicodedata.normalize('NFKC', s2)
-    return compare_digest(s1, s2)
+    if sys.version.startswith('3'):
+        return compare_digest(s1.encode(), s2.encode())
+    else:
+        return compare_digest(s1, s2)

--- a/test.py
+++ b/test.py
@@ -261,6 +261,9 @@ class StringComparisonTest(CompareDigestTest):
     def test_fullwidth_input(self):
         self.assertTrue(self.method("ｘs１２３45", "xs12345"))
 
+    def test_unicode_equal(self):
+        self.assertTrue(self.method("ěšč45", "ěšč45"))
+
 
 class CounterOffsetTest(unittest.TestCase):
     def test_counter_offset(self):


### PR DESCRIPTION
Prevents `TypeError` from being raised, when user inputs a unicode character.