### PR TITLE
Add random_hex function

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -22,6 +22,6 @@ def random_base32(length=16, random=None,
         for _ in range(length)
     )
 
-def random_hex(length=16, random=None, 
+def random_hex(length=16, random=None,
                chars=list('ABCDEF0123456789')):
     return random_base32(length=length, random=None, chars=chars)

--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -21,3 +21,7 @@ def random_base32(length=16, random=None,
         random.choice(chars)
         for _ in range(length)
     )
+
+def random_hex(length=16, random=None, 
+               chars=list('ABCDEF0123456789')):
+    return random_base32(length=length, random=None, chars=chars)


### PR DESCRIPTION
Some TOTP systems don't accept Base32 input, and want hex.  Create a simple 'random_hex' function that wraps around random_base32.

Such a system would be Sophos' XG Firewall when adding customized seeds.  These require HEX keys, and there's no outright mechanism to create them here.  This is a simple wrapper function added around preexisting random_base32 that provides HEX returns.