### PR TITLE
Document base class OTP

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,9 @@ API documentation
 .. automodule:: pyotp
    :members:
 
+.. automodule:: pyotp.otp
+   :members:
+
 .. automodule:: pyotp.totp
    :members:
 


### PR DESCRIPTION
`*args, **kwargs` are not mentioned in `HOTP` and `TOTP` but in `OTP`.