### PR TITLE
Support for 7-digit codes in 'parse_uri'.

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -75,8 +75,8 @@ def parse_uri(uri: str) -> OTP:
                 raise ValueError('Invalid value for algorithm, must be SHA1, SHA256 or SHA512')
         elif key == 'digits':
             digits = int(value)
-            if digits not in [6, 8]:
-                raise ValueError('Digits may only be 6 or 8')
+            if digits not in [6, 7, 8]:
+                raise ValueError('Digits may only be 6, 7, or 8')
             otp_data['digits'] = digits
         elif key == 'period':
             otp_data['interval'] = int(value)


### PR DESCRIPTION
Super minor change. Since Authy uses 7-digit TOTP codes, URIs with a `digits=7` parameter can sometimes be a valid option. This just updates the assertation in `parse_uri` to allow 7-digit codes, too.