### PR TITLE
Add optional image parameter to provisioning_uri

### DIFF
--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -44,7 +44,8 @@ class HOTP(OTP):
             self,
             name: Optional[str] = None,
             initial_count: Optional[int] = None,
-            issuer_name: Optional[str] = None) -> str:
+            issuer_name: Optional[str] = None,
+            image: Optional[str] = None) -> str:
         """
         Returns the provisioning URI for the OTP.  This can then be
         encoded in a QR Code and used to provision an OTP app like
@@ -65,5 +66,6 @@ class HOTP(OTP):
             initial_count=initial_count if initial_count else self.initial_count,
             issuer=issuer_name if issuer_name else self.issuer,
             algorithm=self.digest().name,
-            digits=self.digits
+            digits=self.digits,
+            image=image,
         )

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -69,8 +69,9 @@ class TOTP(OTP):
             return False
 
         return utils.strings_equal(str(otp), str(self.at(for_time)))
+    def provisioning_uri(self, name: Optional[str] = None, issuer_name: Optional[str] = None,
+                         image: Optional[str] = None) -> str:
 
-    def provisioning_uri(self, name: Optional[str] = None, issuer_name: Optional[str] = None) -> str:
         """
         Returns the provisioning URI for the OTP.  This can then be
         encoded in a QR Code and used to provision an OTP app like

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -69,6 +69,7 @@ class TOTP(OTP):
             return False
 
         return utils.strings_equal(str(otp), str(self.at(for_time)))
+
     def provisioning_uri(self, name: Optional[str] = None, issuer_name: Optional[str] = None,
                          image: Optional[str] = None) -> str:
 
@@ -84,7 +85,7 @@ class TOTP(OTP):
         return utils.build_uri(self.secret, name if name else self.name,
                                issuer=issuer_name if issuer_name else self.issuer,
                                algorithm=self.digest().name,
-                               digits=self.digits, period=self.interval)
+                               digits=self.digits, period=self.interval, image=image)
 
     def timecode(self, for_time: datetime.datetime) -> int:
         """

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -60,7 +60,7 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
     if image:
         image_uri = urlparse(image)
         if image_uri.scheme != 'https' or not image_uri.netloc or not image_uri.path:
-            raise Exception('Invalid image uri {image_uri}'.format(image_uri=image_uri))
+            raise ValueError('{} is not a valid url'.format(image_uri))
         url_args['image'] = image
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,7 +1,7 @@
 import unicodedata
 from hmac import compare_digest
 from typing import Dict, Optional, Union
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 
 
 def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issuer: Optional[str] = None,
@@ -58,6 +58,8 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
     if is_period_set:
         url_args['period'] = period
     if image:
+        image_uri = urlparse(image)
+        assert image_uri.scheme == 'https' and image_uri.netloc and image_uri.path, f'Invalid image uri {image_uri}'
         url_args['image'] = image
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -60,7 +60,7 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
     if image:
         image_uri = urlparse(image)
         if image_uri.scheme != 'https' or not image_uri.netloc or not image_uri.path:
-            raise Exception(f'Invalid image uri {image_uri}')
+            raise Exception('Invalid image uri {image_uri}'.format(image_uri=image_uri))
         url_args['image'] = image
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -5,7 +5,8 @@ from urllib.parse import quote, urlencode
 
 
 def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issuer: Optional[str] = None,
-              algorithm: Optional[str] = None, digits: Optional[int] = None, period: Optional[int] = None) -> str:
+              algorithm: Optional[str] = None, digits: Optional[int] = None, period: Optional[int] = None,
+              image: Optional[str] = None) -> str:
     """
     Returns the provisioning URI for the OTP; works for either TOTP or HOTP.
 
@@ -55,6 +56,8 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
         url_args['digits'] = digits
     if is_period_set:
         url_args['period'] = period
+    if image:
+        url_args['image'] = image
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))
     return uri

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -59,7 +59,8 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
         url_args['period'] = period
     if image:
         image_uri = urlparse(image)
-        assert image_uri.scheme == 'https' and image_uri.netloc and image_uri.path, f'Invalid image uri {image_uri}'
+        if image_uri.scheme != 'https' or not image_uri.netloc or not image_uri.path:
+            raise Exception(f'Invalid image uri {image_uri}')
         url_args['image'] = image
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -28,6 +28,7 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
     :param digits: the length of the OTP generated code.
     :param period: the number of seconds the OTP generator is set to
         expire every code.
+    :param image: optional logo image url
     :returns: provisioning uri
     """
     # initial_count may be 0 as a valid param

--- a/test.py
+++ b/test.py
@@ -414,7 +414,7 @@ class ParseUriTest(unittest.TestCase):
 
         self.assertEqual(otp.provisioning_uri(name='n', issuer_name='i', image='https://test.net/test.png'),
                         'otpauth://totp/i:n?secret=GEZDGNBV&issuer=i&algorithm=SHA512&image=https%3A%2F%2Ftest.net%2Ftest.png')
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             otp.provisioning_uri(name='n', issuer_name='i', image='nourl')
 
 class Timecop(object):

--- a/test.py
+++ b/test.py
@@ -412,6 +412,10 @@ class ParseUriTest(unittest.TestCase):
         self.assertEqual(otp.at(0), '816660')
         self.assertEqual(otp.at(9000), '524153')
 
+        self.assertEqual(otp.provisioning_uri(name='n', issuer_name='i', image='https://test.net/test.png'),
+                        'otpauth://totp/i:n?secret=GEZDGNBV&issuer=i&algorithm=SHA512&image=https%3A%2F%2Ftest.net%2Ftest.png')
+        with self.assertRaises(Exception):
+            otp.provisioning_uri(name='n', issuer_name='i', image='nourl')
 
 class Timecop(object):
     """


### PR DESCRIPTION
This PR adds an optional image parameter to the uri returned by provisioning_uri.

The image parameter allows for the inclusion of a logo in the Authy and FreeOTP apps.

I did this without realizing there was an existing issue: https://github.com/pyauth/pyotp/issues/96