### PR TITLE
Allow passing secrets as bytes

### DIFF
--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from . import utils
 from .otp import OTP
@@ -9,10 +9,10 @@ class HOTP(OTP):
     """
     Handler for HMAC-based OTP counters.
     """
-    def __init__(self, s: str, digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
+    def __init__(self, s: Union[bytes, str], digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
                  issuer: Optional[str] = None, initial_count: int = 0) -> None:
         """
-        :param s: secret in base32 format
+        :param s: secret in base32 format or bytes
         :param initial_count: starting HMAC counter value, defaults to 0
         :param digits: number of integers in the OTP. Some apps expect this to be 6 digits, others support more.
         :param digest: digest function to use in the HMAC (expected to be sha1)

--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -1,7 +1,8 @@
-import base64
 import hashlib
 import hmac
 from typing import Any, Optional
+
+from .utils import coerce_bytes
 
 
 class OTP(object):
@@ -23,7 +24,7 @@ class OTP(object):
         """
         if input < 0:
             raise ValueError('input must be positive integer')
-        hasher = hmac.new(self.byte_secret(), self.int_to_bytestring(input), self.digest)
+        hasher = hmac.new(coerce_bytes(self.secret), self.int_to_bytestring(input), self.digest)
         hmac_hash = bytearray(hasher.digest())
         offset = hmac_hash[-1] & 0xf
         code = ((hmac_hash[offset] & 0x7f) << 24 |
@@ -35,13 +36,6 @@ class OTP(object):
             str_code = '0' + str_code
 
         return str_code
-
-    def byte_secret(self) -> bytes:
-        secret = self.secret
-        missing_padding = len(secret) % 8
-        if missing_padding != 0:
-            secret += '=' * (8 - missing_padding)
-        return base64.b32decode(secret, casefold=True)
 
     @staticmethod
     def int_to_bytestring(i: int, padding: int = 8) -> bytes:

--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -1,6 +1,6 @@
 import hashlib
 import hmac
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from .utils import coerce_bytes
 
@@ -9,7 +9,7 @@ class OTP(object):
     """
     Base class for OTP handlers.
     """
-    def __init__(self, s: str, digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
+    def __init__(self, s: Union[bytes, str], digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
                  issuer: Optional[str] = None) -> None:
         self.digits = digits
         self.digest = digest

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -12,10 +12,10 @@ class TOTP(OTP):
     """
     Handler for time-based OTP counters.
     """
-    def __init__(self, s: str, digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
+    def __init__(self, s: Union[bytes, str], digits: int = 6, digest: Any = hashlib.sha1, name: Optional[str] = None,
                  issuer: Optional[str] = None, interval: int = 30) -> None:
         """
-        :param s: secret in base32 format
+        :param s: secret in base32 format or bytes
         :param interval: the time interval in seconds for OTP. This defaults to 30.
         :param digits: number of integers in the OTP. Some apps expect this to be 6 digits, others support more.
         :param digest: digest function to use in the HMAC (expected to be sha1)

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -5,7 +5,7 @@ from typing import Dict, Optional, Union
 from urllib.parse import quote, urlencode, urlparse
 
 
-def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issuer: Optional[str] = None,
+def build_uri(secret: Union[bytes, str], name: str, initial_count: Optional[int] = None, issuer: Optional[str] = None,
               algorithm: Optional[str] = None, digits: Optional[int] = None, period: Optional[int] = None,
               image: Optional[str] = None) -> str:
     """
@@ -43,7 +43,7 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
     otp_type = 'hotp' if is_initial_count_present else 'totp'
     base_uri = 'otpauth://{0}/{1}?{2}'
 
-    url_args = {'secret': secret}  # type: Dict[str, Union[None, int, str]]
+    url_args = {'secret': coerce_str(secret)}  # type: Dict[str, Union[None, int, str]]
 
     label = quote(name)
     if issuer is not None:
@@ -69,8 +69,16 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
 
 
 def coerce_bytes(secret: str):
+    if isinstance(secret, bytes):
+        return secret
     secret += -len(secret) % 8 * '='  # fix padding
     return base64.b32decode(secret, casefold=True)
+
+
+def coerce_str(secret: Union[bytes, str]):
+    if isinstance(secret, str):
+        return secret
+    return base64.b32encode(secret).rstrip(b'=').decode('ascii')
 
 
 def strings_equal(s1: str, s2: str) -> bool:

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,3 +1,4 @@
+import base64
 import unicodedata
 from hmac import compare_digest
 from typing import Dict, Optional, Union
@@ -65,6 +66,11 @@ def build_uri(secret: str, name: str, initial_count: Optional[int] = None, issue
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))
     return uri
+
+
+def coerce_bytes(secret: str):
+    secret += -len(secret) % 8 * '='  # fix padding
+    return base64.b32decode(secret, casefold=True)
 
 
 def strings_equal(s1: str, s2: str) -> bool:

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 import base64, datetime, hashlib, os, sys, unittest
+from unittest import mock
 from warnings import warn
 
 from urllib.parse import urlparse, parse_qsl
@@ -304,6 +305,17 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
             pyotp.random_base32(length=31)
         with self.assertRaises(ValueError):
             pyotp.random_hex(length=39)
+
+
+class CoercionTest(unittest.TestCase):
+    @mock.patch.object(pyotp.otp, "coerce_bytes", return_value=b'\00')
+    def test_call_coerce_bytes_for_otp(self, mock):
+        pyotp.OTP('').generate_otp(123)
+        self.assertTrue(mock.called)
+
+    def test_to_bytes(self):
+        func = pyotp.utils.coerce_bytes
+        self.assertEqual(func('ASDA'), b'\x04\x86')
 
 
 class CompareDigestTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -167,7 +167,7 @@ class TOTPExampleValuesFromTheRFC(unittest.TestCase):
 
     def test_match_rfc(self):
         for digest, secret in self.RFC_VALUES:
-            totp = pyotp.TOTP(base64.b32encode(secret), 8, digest)
+            totp = pyotp.TOTP(base64.b32encode(secret).decode("ascii"), 8, digest)
             for utime, code in self.RFC_VALUES[(digest, secret)]:
                 if utime > sys.maxsize:
                     warn("32-bit platforms use native functions to handle timestamps, so they fail this test" +

--- a/test.py
+++ b/test.py
@@ -313,9 +313,20 @@ class CoercionTest(unittest.TestCase):
         pyotp.OTP('').generate_otp(123)
         self.assertTrue(mock.called)
 
+    @mock.patch.object(pyotp.utils, "coerce_str")
+    def test_call_coerce_str_for_uri(self, mock):
+        pyotp.utils.build_uri('', '')
+        self.assertTrue(mock.called)
+
     def test_to_bytes(self):
         func = pyotp.utils.coerce_bytes
         self.assertEqual(func('ASDA'), b'\x04\x86')
+        self.assertEqual(func(b'\x04\x86'), b'\x04\x86')
+
+    def test_to_str(self):
+        func = pyotp.utils.coerce_str
+        self.assertEqual(func(b'\x04\x86'), 'ASDA')
+        self.assertEqual(func('ASDA'), 'ASDA')
 
 
 class CompareDigestTest(unittest.TestCase):


### PR DESCRIPTION
When the storage backend has the secrets as bytes, it is unnecessary to convert to string for passing into pyotp, which converts it back to bytes to compute the digest.

This PR allows passing the secret directly as bytes, and makes some related code adjustments. It does so by coercing the type as needed. (I also considered storing only bytes in `self.secret`, but rejected the idea as it would break uses that write it directly.)