### PR TITLE
Fixes for docs rendering 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,10 +10,13 @@ version = ""
 release = ""
 language = "en"
 master_doc = "index"
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.intersphinx"]
 source_suffix = [".rst", ".md"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "sphinx"
+intersphinx_mapping = {
+    "https://docs.python.org/3": None,
+}
 
 if "readthedocs.org" in os.getcwd().split("/"):
     with open("index.rst", "w") as fh:

--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -14,7 +14,7 @@ class HOTP(OTP):
         self,
         s: str,
         digits: int = 6,
-        digest: Any = hashlib.sha1,
+        digest: Any = None,
         name: Optional[str] = None,
         issuer: Optional[str] = None,
         initial_count: int = 0,
@@ -23,10 +23,13 @@ class HOTP(OTP):
         :param s: secret in base32 format
         :param initial_count: starting HMAC counter value, defaults to 0
         :param digits: number of integers in the OTP. Some apps expect this to be 6 digits, others support more.
-        :param digest: digest function to use in the HMAC (expected to be sha1)
+        :param digest: digest function to use in the HMAC (expected to be SHA1)
         :param name: account name
         :param issuer: issuer
         """
+        if digest is None:
+            digest = hashlib.sha1
+
         self.initial_count = initial_count
         super().__init__(s=s, digits=digits, digest=digest, name=name, issuer=issuer)
 

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -17,7 +17,7 @@ class TOTP(OTP):
         self,
         s: str,
         digits: int = 6,
-        digest: Any = hashlib.sha1,
+        digest: Any = None,
         name: Optional[str] = None,
         issuer: Optional[str] = None,
         interval: int = 30,
@@ -26,10 +26,13 @@ class TOTP(OTP):
         :param s: secret in base32 format
         :param interval: the time interval in seconds for OTP. This defaults to 30.
         :param digits: number of integers in the OTP. Some apps expect this to be 6 digits, others support more.
-        :param digest: digest function to use in the HMAC (expected to be sha1)
+        :param digest: digest function to use in the HMAC (expected to be SHA1)
         :param name: account name
         :param issuer: issuer
         """
+        if digest is None:
+            digest = hashlib.sha1
+
         self.interval = interval
         super().__init__(s=s, digits=digits, digest=digest, name=name, issuer=issuer)
 
@@ -37,7 +40,9 @@ class TOTP(OTP):
         """
         Accepts either a Unix timestamp integer or a datetime object.
 
-        To get the time until the next timecode change (seconds until the current OTP expires), use this instead::
+        To get the time until the next timecode change (seconds until the current OTP expires), use this instead:
+
+        .. code:: python
 
             totp = pyotp.TOTP(...)
             time_remaining = totp.interval - datetime.datetime.now().timestamp() % totp.interval


### PR DESCRIPTION
This has two small modifications:
* adds `sphinx.ext.intersphinx` to link types back to https://docs.python.org/3/library/typing.html
* Remove a default value in the `TOTP` / `HOTP` classes so the type hints get rendered correctly (this is likely a bug in `sphinx` and just working around it).

This is how it currently looks on https://pyauth.github.io/pyotp/#pyotp.totp.TOTP
<p align="center">
<img src="https://user-images.githubusercontent.com/777240/201404619-11abf600-bbd6-42bb-b63b-d5411ea2cf8e.png" width="700">
</p>

And this is after the changes in the current PR
<p align="center">
<img src="https://user-images.githubusercontent.com/777240/201404648-059dbe16-271c-48ef-93fb-1789b0a912ff.png" width=700>
</p>