### PR TITLE
Add `parse_uri()` support for Steam TOTP

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -40,6 +40,9 @@ def parse_uri(uri: str) -> OTP:
     # Secret (to be filled in later)
     secret = None
 
+    # Encoder (to be filled in later)
+    encoder = None
+
     # Data we'll parse to the correct constructor
     otp_data: Dict[str, Any] = {}
 
@@ -74,10 +77,10 @@ def parse_uri(uri: str) -> OTP:
                 otp_data["digest"] = hashlib.sha512
             else:
                 raise ValueError("Invalid value for algorithm, must be SHA1, SHA256 or SHA512")
+        elif key == "encoder":
+            encoder = value
         elif key == "digits":
             digits = int(value)
-            if digits not in [6, 7, 8]:
-                raise ValueError("Digits may only be 6, 7, or 8")
             otp_data["digits"] = digits
         elif key == "period":
             otp_data["interval"] = int(value)
@@ -85,11 +88,18 @@ def parse_uri(uri: str) -> OTP:
             otp_data["initial_count"] = int(value)
         elif key != "image":
             raise ValueError("{} is not a valid parameter".format(key))
-
+    
+    if encoder != "steam":
+        digits = otp_data.get("digits")
+        if digits is not None and digits not in [6, 7, 8]:
+            raise ValueError("Digits may only be 6, 7, or 8")
+    
     if not secret:
         raise ValueError("No secret found in URI")
 
     # Create objects
+    if encoder == "steam":
+        return contrib.Steam(secret, **otp_data)
     if parsed_uri.netloc == "totp":
         return TOTP(secret, **otp_data)
     elif parsed_uri.netloc == "hotp":

--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -43,6 +43,9 @@ def parse_uri(uri: str) -> OTP:
     # Encoder (to be filled in later)
     encoder = None
 
+    # Digits (to be filled in later)
+    digits = None
+
     # Data we'll parse to the correct constructor
     otp_data: Dict[str, Any] = {}
 
@@ -90,7 +93,6 @@ def parse_uri(uri: str) -> OTP:
             raise ValueError("{} is not a valid parameter".format(key))
     
     if encoder != "steam":
-        digits = otp_data.get("digits")
         if digits is not None and digits not in [6, 7, 8]:
             raise ValueError("Digits may only be 6, 7, or 8")
     

--- a/src/pyotp/contrib/steam.py
+++ b/src/pyotp/contrib/steam.py
@@ -12,7 +12,14 @@ class Steam(TOTP):
     Steam's custom TOTP. Subclass of `pyotp.totp.TOTP`.
     """
 
-    def __init__(self, s: str, name: Optional[str] = None, issuer: Optional[str] = None, interval: int = 30, digits: int = 5) -> None:
+    def __init__(
+        self,
+        s: str,
+        name: Optional[str] = None,
+        issuer: Optional[str] = None,
+        interval: int = 30,
+        digits: int = 5
+    ) -> None:
         """
         :param s: secret in base32 format
         :param interval: the time interval in seconds for OTP. This defaults to 30.

--- a/src/pyotp/contrib/steam.py
+++ b/src/pyotp/contrib/steam.py
@@ -12,7 +12,7 @@ class Steam(TOTP):
     Steam's custom TOTP. Subclass of `pyotp.totp.TOTP`.
     """
 
-    def __init__(self, s: str, name: Optional[str] = None, issuer: Optional[str] = None, interval: int = 30) -> None:
+    def __init__(self, s: str, name: Optional[str] = None, issuer: Optional[str] = None, interval: int = 30, digits: int = 5) -> None:
         """
         :param s: secret in base32 format
         :param interval: the time interval in seconds for OTP. This defaults to 30.

--- a/test.py
+++ b/test.py
@@ -364,6 +364,13 @@ class ParseUriTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             pyotp.parse_uri("otpauth://totp?algorithm=aes")
         self.assertEqual("Invalid value for algorithm, must be SHA1, SHA256 or SHA512", str(cm.exception))
+    
+    def test_parse_steam(self):
+        otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=SOME_SECRET&encoder=steam")
+        self.assertEqual(type(otp), pyotp.contrib.Steam)
+
+        otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=SOME_SECRET")
+        self.assertNotEqual(type(otp), pyotp.contrib.Steam)
 
     @unittest.skipIf(sys.version_info < (3, 6), "Skipping test that requires deterministic dict key enumeration")
     def test_algorithms(self):
@@ -420,6 +427,20 @@ class ParseUriTest(unittest.TestCase):
         otp = pyotp.parse_uri(otp.provisioning_uri(name="n", issuer_name="i", image="https://test.net/test.png"))
         self.assertEqual(hashlib.sha512, otp.digest)
 
+        otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=FMXNK4QEGKVPULRTADY6JIDK5VHUBGZW&encoder=steam")
+        self.assertEqual(type(otp), pyotp.contrib.Steam)
+        self.assertEqual(otp.at(0), "C5V56")
+        self.assertEqual(otp.at(30), "QJY8Y")
+        self.assertEqual(otp.at(60), "R3WQY")
+        self.assertEqual(otp.at(90), "JG3T3")
+
+        # period and digits should be ignored
+        otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=FMXNK4QEGKVPULRTADY6JIDK5VHUBGZW&period=15&digits=7&encoder=steam")
+        self.assertEqual(type(otp), pyotp.contrib.Steam)
+        self.assertEqual(otp.at(0), "C5V56")
+        self.assertEqual(otp.at(30), "QJY8Y")
+        self.assertEqual(otp.at(60), "R3WQY")
+        self.assertEqual(otp.at(90), "JG3T3")
 
 class Timecop(object):
     """


### PR DESCRIPTION
`otpauth://` URIs with the parameter `encoder=steam` are parsed as Steam TOTP.
I have used the example URI in [this comment](https://github.com/pyauth/pyotp/issues/127#issuecomment-1531582830) as a basis.