### PR TITLE
Use mypy recommended conditional imports for compats

### DIFF
--- a/src/pyotp/compat.py
+++ b/src/pyotp/compat.py
@@ -1,7 +1,9 @@
+import sys
+
 # Use secrets module if available (Python version >= 3.6) per PEP 506
-try:
-    from secrets import SystemRandom  # type: ignore
-except ImportError:
+if sys.version_info >= (3, 6):
+    from secrets import SystemRandom
+else:
     from random import SystemRandom
 
 random = SystemRandom()


### PR DESCRIPTION
Hello !

Concerning conditional imports based on the actual Python version at runtime, Mypy recommendation is to explicitly use `sys.version_info` to trigger the relevant import depending on the Python version.

Reference to the documentation: https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks

I apply this approach to the `compat` module.

As a consequence, Mypy does an educated guess on the imports, and `#type: ignore` inline comment is not needed anymore.
