### PR TITLE
use strings as immutable default arguments

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -10,7 +10,7 @@ from .otp import OTP as OTP
 from .totp import TOTP as TOTP
 
 
-def random_base32(length: int = 32, chars: Sequence[str] = list("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")) -> str:
+def random_base32(length: int = 32, chars: Sequence[str] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567") -> str:
     # Note: the otpauth scheme DOES NOT use base32 padding for secret lengths not divisible by 8.
     # Some third-party tools have bugs when dealing with such secrets.
     # We might consider warning the user when generating a secret of length not divisible by 8.
@@ -20,7 +20,7 @@ def random_base32(length: int = 32, chars: Sequence[str] = list("ABCDEFGHIJKLMNO
     return "".join(random.choice(chars) for _ in range(length))
 
 
-def random_hex(length: int = 40, chars: Sequence[str] = list("ABCDEF0123456789")) -> str:
+def random_hex(length: int = 40, chars: Sequence[str] = "ABCDEF0123456789") -> str:
     if length < 40:
         raise ValueError("Secrets should be at least 160 bits")
     return random_base32(length=length, chars=chars)


### PR DESCRIPTION
Fixes #161 

Avoid using mutable objects as default arguments as functions. Even though this particular usage was safe, it opens up the projects to issues down the road if the default argument is mutated within the function. For this usage, we don't need an actual `list` object, just a sequence of strings, so we can use a string itself.