### PR TITLE
Add color option for provisioning uri.

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -89,13 +89,13 @@ def parse_uri(uri: str) -> OTP:
             otp_data["interval"] = int(value)
         elif key == "counter":
             otp_data["initial_count"] = int(value)
-        elif key != "image":
+        elif key not in {"image", "color"}:
             raise ValueError("{} is not a valid parameter".format(key))
-    
+
     if encoder != "steam":
         if digits is not None and digits not in [6, 7, 8]:
             raise ValueError("Digits may only be 6, 7, or 8")
-    
+
     if not secret:
         raise ValueError("No secret found in URI")
 

--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -57,6 +57,7 @@ class HOTP(OTP):
         initial_count: Optional[int] = None,
         issuer_name: Optional[str] = None,
         image: Optional[str] = None,
+        color: Optional[str] = None,
     ) -> str:
         """
         Returns the provisioning URI for the OTP.  This can then be
@@ -80,4 +81,5 @@ class HOTP(OTP):
             algorithm=self.digest().name,
             digits=self.digits,
             image=image,
+            color=color,
         )

--- a/src/pyotp/totp.py
+++ b/src/pyotp/totp.py
@@ -84,7 +84,7 @@ class TOTP(OTP):
         return utils.strings_equal(str(otp), str(self.at(for_time)))
 
     def provisioning_uri(
-        self, name: Optional[str] = None, issuer_name: Optional[str] = None, image: Optional[str] = None
+        self, name: Optional[str] = None, issuer_name: Optional[str] = None, image: Optional[str] = None, color: Optional[str] = None,
     ) -> str:
 
         """
@@ -104,6 +104,7 @@ class TOTP(OTP):
             digits=self.digits,
             period=self.interval,
             image=image,
+            color=color,
         )
 
     def timecode(self, for_time: datetime.datetime) -> int:

--- a/src/pyotp/utils.py
+++ b/src/pyotp/utils.py
@@ -1,5 +1,6 @@
 import unicodedata
 from hmac import compare_digest
+import re
 from typing import Dict, Optional, Union
 from urllib.parse import quote, urlencode, urlparse
 
@@ -13,6 +14,7 @@ def build_uri(
     digits: Optional[int] = None,
     period: Optional[int] = None,
     image: Optional[str] = None,
+    color: Optional[str] = None,
 ) -> str:
     """
     Returns the provisioning URI for the OTP; works for either TOTP or HOTP.
@@ -69,6 +71,10 @@ def build_uri(
         if image_uri.scheme != "https" or not image_uri.netloc or not image_uri.path:
             raise ValueError("{} is not a valid url".format(image_uri))
         url_args["image"] = image
+    if color:
+        if not re.match(r'[0-9a-fA-F]{6}', color):
+            raise ValueError("{} is not a valid RRGGBB hex color value".format(color))
+        url_args["color"] = color
 
     uri = base_uri.format(otp_type, label, urlencode(url_args).replace("+", "%20"))
     return uri

--- a/test.py
+++ b/test.py
@@ -364,7 +364,7 @@ class ParseUriTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             pyotp.parse_uri("otpauth://totp?algorithm=aes")
         self.assertEqual("Invalid value for algorithm, must be SHA1, SHA256 or SHA512", str(cm.exception))
-    
+
     def test_parse_steam(self):
         otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=SOME_SECRET&encoder=steam")
         self.assertEqual(type(otp), pyotp.contrib.Steam)
@@ -425,6 +425,16 @@ class ParseUriTest(unittest.TestCase):
             otp.provisioning_uri(name="n", issuer_name="i", image="nourl")
 
         otp = pyotp.parse_uri(otp.provisioning_uri(name="n", issuer_name="i", image="https://test.net/test.png"))
+        self.assertEqual(hashlib.sha512, otp.digest)
+
+        self.assertEqual(
+            otp.provisioning_uri(name="n", issuer_name="i", color="FF0000"),
+            "otpauth://totp/i:n?secret=GEZDGNBV&issuer=i&algorithm=SHA512&color=FF0000",
+        )
+        with self.assertRaises(ValueError):
+            otp.provisioning_uri(name="n", issuer_name="i", color="invalid_value")
+
+        otp = pyotp.parse_uri(otp.provisioning_uri(name="n", issuer_name="i", color="FF0000"))
         self.assertEqual(hashlib.sha512, otp.digest)
 
         otp = pyotp.parse_uri("otpauth://totp/Steam:?secret=FMXNK4QEGKVPULRTADY6JIDK5VHUBGZW&encoder=steam")


### PR DESCRIPTION
Add color option for provisioning uri and allow parse_uri to accept optional color uri parameter.

The color option is used by FreeOTP with image option: [https://github.com/npmccallum/freeotp-android/blob/master/URI.md](https://github.com/npmccallum/freeotp-android/blob/master/URI.md)