### PR TITLE
docs: fix deprecated intersphinx_mapping format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@ source_suffix = [".rst", ".md"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 pygments_style = "sphinx"
 intersphinx_mapping = {
-    "https://docs.python.org/3": None,
+    "python": ("https://docs.python.org/3", None),
 }
 templates_path = [""]
 ogp_site_url = "https://pyauth.github.io/pyotp/"


### PR DESCRIPTION
Since Sphinx 8.0 the docs cannot be build as the old `intersphinx_mapping` format is still used which is deprecated since Sphinx 0.5.