### PR TITLE
Replace license classifier with license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "PyOTP"
 description = "Python One Time Password Library"
 readme = "README.rst"
 requires-python = ">=3.8"
-license = { text = "MIT License" }
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{ name = "Andrey Kislyuk"}, {email = "kislyuk@gmail.com" }]
 maintainers = [{ name = "Andrey Kislyuk"}, {email = "kislyuk@gmail.com" }]
 dynamic = ["version"]
 classifiers = [
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: POSIX",
   "Programming Language :: Python",


### PR DESCRIPTION
- use metadata 2.4 style

While checking the license I noticed that the license is MIT, but the license classifier was set to Apache License.
While correcting this, I replaced the license classifier with a license expression as per PEP-639.