### PR TITLE
Replace ubuntu-20.04 with 22.04 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04, ubuntu-latest, macos-latest
+    runs-on: ${{ matrix.os }}
+    env:
+      PIP_DISABLE_PIP_VERSION_CHECK: 1
     strategy:
       matrix:
+        os: [ubuntu-22.04, ubuntu-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: make install

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test_deps:
 	python -m pip install .[test]
 
 lint:
-	ruff src
+	ruff check src
 	mypy --install-types --non-interactive --check-untyped-defs src
 
 test:


### PR DESCRIPTION
- ubuntu-20.04 is no longer supported, ubuntu-latest is now 24.04
- fix workflow syntax
- fix ruff syntax

I had noticed that most of the tests fail because they can't find a runner (my PR was merged, thanks for that!).