### PR TITLE
Fix parse_uri mis-parsing of encoded colon in issuer/account name

### DIFF
--- a/src/pyotp/__init__.py
+++ b/src/pyotp/__init__.py
@@ -49,19 +49,26 @@ def parse_uri(uri: str) -> OTP:
     # Data we'll parse to the correct constructor
     otp_data: Dict[str, Any] = {}
 
-    # Parse with URLlib
-    parsed_uri = urlparse(unquote(uri))
+    # Parse the URI structure first, then unquote individual components.
+    # Unquoting the whole URI before splitting the label would turn an
+    # encoded colon (%3A) inside the issuer or account name into a literal
+    # ":" and mis-parse the issuer:account separator (see GitHub issue #174).
+    parsed_uri = urlparse(uri)
 
     if parsed_uri.scheme != "otpauth":
         raise ValueError("Not an otpauth URI")
 
-    # Parse issuer/accountname info
-    accountinfo_parts = split(":|%3A", parsed_uri.path[1:], maxsplit=1)
+    # Parse issuer/accountname info. The label uses a literal ":" as the
+    # issuer:account separator; a percent-encoded "%3A" is a colon that is
+    # part of the issuer or account name, not a separator. Split on the
+    # literal ":" while the components are still percent-encoded, then
+    # unquote each component on its own.
+    accountinfo_parts = split(":", parsed_uri.path[1:], maxsplit=1)
     if len(accountinfo_parts) == 1:
-        otp_data["name"] = accountinfo_parts[0]
+        otp_data["name"] = unquote(accountinfo_parts[0])
     else:
-        otp_data["issuer"] = accountinfo_parts[0]
-        otp_data["name"] = accountinfo_parts[1]
+        otp_data["issuer"] = unquote(accountinfo_parts[0])
+        otp_data["name"] = unquote(accountinfo_parts[1])
 
     # Parse values
     for key, value in parse_qsl(parsed_uri.query):

--- a/test.py
+++ b/test.py
@@ -458,6 +458,32 @@ class ParseUriTest(unittest.TestCase):
 
         pyotp.parse_uri("otpauth://totp?secret=abc&image=foobar")
 
+    def test_parse_encoded_colon_in_label(self):
+        # Regression test for issue #174: an encoded colon (%3A) inside the
+        # issuer or account name must not be treated as the issuer:account
+        # separator. The label issuer and the query issuer should still match.
+        otp = pyotp.parse_uri(
+            "otpauth://totp/Text%3A%20More%20Text:Secret?secret=FFFFFFFAAAAAABBBBBBB&issuer=Text%3A%20More%20Text"
+        )
+        self.assertEqual(otp.name, "Secret")
+        self.assertEqual(otp.issuer, "Text: More Text")
+
+        # An encoded colon in the account name (no issuer) is kept intact.
+        otp = pyotp.parse_uri("otpauth://totp/a%3Ab?secret=GEZDGNBV")
+        self.assertEqual(otp.name, "a:b")
+        self.assertIsNone(otp.issuer)
+
+        # Round-trip: building the URI and parsing it back preserves both parts.
+        source = pyotp.TOTP("FFFFFFFAAAAAABBBBBBB", name="Secret", issuer="Text: More Text")
+        roundtrip = pyotp.parse_uri(source.provisioning_uri())
+        self.assertEqual(roundtrip.name, "Secret")
+        self.assertEqual(roundtrip.issuer, "Text: More Text")
+
+        # A percent-encoded space in a plain issuer (no colon) still decodes.
+        otp = pyotp.parse_uri("otpauth://totp/Big%20Corp:bob?secret=GEZDGNBV&issuer=Big%20Corp")
+        self.assertEqual(otp.name, "bob")
+        self.assertEqual(otp.issuer, "Big Corp")
+
 
 class Timecop(object):
     """


### PR DESCRIPTION
## Summary

Fixes #174.

`parse_uri` called `unquote()` on the whole URI before splitting the label
into issuer and account name. That decoded a percent-encoded colon (`%3A`)
inside the issuer or account name into a literal `:`, which was then treated
as the issuer:account separator. As a result, a valid URI such as the one in
the issue:

```
otpauth://totp/Text%3A%20More%20Text:Secret?secret=FFFFFFFAAAAAABBBBBBB&issuer=Text%3A%20More%20Text
```

was mis-parsed (issuer became `Text`, account became `More Text:Secret`), and
the label issuer no longer matched the `issuer` query parameter, raising:

```
ValueError: If issuer is specified in both label and parameters, it should be equal.
```

## Fix

Parse the URI structure first with `urlparse`, then split the label on the
literal `:` separator while the components are still percent-encoded, and
`unquote` each component (issuer and account name) on its own. A percent-encoded
`%3A` now stays part of the component it belongs to instead of being mistaken
for the separator.

The previous split also matched a literal `%3A` as a separator, which is what
caused the mis-parse once a producer encoded a colon in the label. Per the
Key URI Format, the separator is a literal `:`; an encoded `%3A` is a colon
that is part of the issuer/account text, so the split now matches only `:`.

The existing validation that the issuer in the label and the issuer query
parameter must match is preserved (both sides are now compared after correct
decoding).

## Tests

Added `ParseUriTest.test_parse_encoded_colon_in_label`, covering:

- the exact URI from the issue (correct issuer/account, no false mismatch error)
- an encoded colon in the account name alone (`a%3Ab` -> `a:b`)
- a round-trip through `provisioning_uri()` for an issuer that contains a colon
- a plain percent-encoded space in the issuer still decoding correctly

The new test fails on the current code with the issue's exact `ValueError` and
passes after the change. The full suite (`python -m pytest test.py`) is green,
and `ruff`, `black`, `isort`, and `mypy` report no issues.
