### PR TITLE
optimize otp int_to_bytestring function

### DIFF
--- a/src/pyotp/otp.py
+++ b/src/pyotp/otp.py
@@ -69,4 +69,4 @@ class OTP(object):
         # It's necessary to convert the final result from bytearray to bytes
         # because the hmac functions in python 2.6 and 3.3 don't work with
         # bytearray
-        return bytes(bytearray(reversed(result)).rjust(padding, b"\0"))
+        return bytes(reversed(result.ljust(padding, b"\0")))


### PR DESCRIPTION
While digging through this repository I found an improvement to the int_to_bytestring function that should be a little bit more lax for the current code to handle since now bytearray doesn't have to be called after using `reversed()` anymore.