### PR TITLE
fix: respect initial_count=0 in HOTP.provisioning_uri()

### DIFF
--- a/src/pyotp/hotp.py
+++ b/src/pyotp/hotp.py
@@ -77,7 +77,7 @@ class HOTP(OTP):
         return utils.build_uri(
             self.secret,
             name=name if name else self.name,
-            initial_count=initial_count if initial_count else self.initial_count,
+            initial_count=initial_count if initial_count is not None else self.initial_count,
             issuer=issuer_name if issuer_name else self.issuer,
             algorithm=self.digest().name,
             digits=self.digits,

--- a/test.py
+++ b/test.py
@@ -97,6 +97,11 @@ class HOTPExampleValuesFromTheRFC(unittest.TestCase):
         )
         self.assertEqual(hotp.provisioning_uri(), pyotp.parse_uri(hotp.provisioning_uri()).provisioning_uri())
 
+        # initial_count=0 must be respected even though 0 is falsy
+        hotp = pyotp.HOTP("wrn3pqx5uqxqvnqr", name="mark@percival", initial_count=7)
+        url = urlparse(hotp.provisioning_uri(initial_count=0))
+        self.assertEqual(dict(parse_qsl(url.query))["counter"], "0")
+
         code = pyotp.totp.TOTP("S46SQCPPTCNPROMHWYBDCTBZXV")
         self.assertEqual(code.provisioning_uri(), "otpauth://totp/Secret?secret=S46SQCPPTCNPROMHWYBDCTBZXV")
         code.verify("123456")


### PR DESCRIPTION
## Problem

`HOTP.provisioning_uri()` accepts an `initial_count` parameter to override the instance's `self.initial_count` in the generated URI, but the guard uses a truthiness check:

```python
initial_count=initial_count if initial_count else self.initial_count,
```

Because `0` is falsy, passing `initial_count=0` is silently discarded and `self.initial_count` is used instead. This produces a wrong `counter` value in the URI when `self.initial_count` is non-zero.

```python
hotp = pyotp.HOTP(secret, name="user", initial_count=7)
uri  = hotp.provisioning_uri(initial_count=0)
# counter=7 in URI — should be counter=0
```

The downstream `build_uri` already handles this correctly with an `is not None` check, and its own comment reads:

```python
# initial_count may be 0 as a valid param
is_initial_count_present = initial_count is not None
```

## Fix

Replace the truthiness check with an identity check in the call site:

```python
initial_count=initial_count if initial_count is not None else self.initial_count,
```

A regression test is included that sets `initial_count=7` on the HOTP object and asserts that `provisioning_uri(initial_count=0)` yields `counter=0`.

This pull request was prepared with the assistance of AI, under my direction and review.